### PR TITLE
Throw CloudflareError instead of JSON error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,9 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+#############
+# Maven
+#############
+
+target

--- a/src/com/cloudflare/api/requests/CloudflareRequest.java
+++ b/src/com/cloudflare/api/requests/CloudflareRequest.java
@@ -66,31 +66,38 @@ public class CloudflareRequest implements Closeable {
             }
             line = null;
 
-            JSONObject JsonResult = (JSONObject) JSONSerializer.toJSON(
+            JSONObject jsonResult = (JSONObject) JSONSerializer.toJSON(
                     sbResult.toString());
             sbResult = null;
 
 
-            if (!JsonResult.containsKey("result")) {
+            if (!jsonResult.containsKey("result")) {
                 throw new CloudflareError("no_result", "No result received", "Result=null");
             }
 
-            CloudflareResult result = CloudflareResult.valueOf(JsonResult.getString(
+            CloudflareResult result = CloudflareResult.valueOf(jsonResult.getString(
                     "result"));
 
             switch (result) {
                 case success: {
-                    if (JsonResult.containsKey("response")) {
-                        return JsonResult.getJSONObject("response");
+                    if (jsonResult.containsKey("response")) {
+                        return jsonResult.getJSONObject("response");
                     } else {
-                        return JsonResult;
+                        return jsonResult;
                     }
                 }
                 case error: {
-                    CloudflareError error = CloudflareErrorEnum.valueOf(JsonResult.getString(
-                            "err_code")).getException(
-                            JsonResult.getString("msg"));
-                    throw error;
+                    String errMessage = "(no message in response)";
+                    if (jsonResult.containsKey("msg")) {
+                        errMessage = jsonResult.getString("msg");
+                    }
+                    String errCode = CloudflareErrorEnum.UNKNOWN_ERROR.toString();
+                    if (jsonResult.containsKey("err_code")) {
+                        errCode = jsonResult.getString("err_code");
+                    }
+                    throw CloudflareErrorEnum
+                        .valueOf(errCode)
+                        .getException(errMessage);
                 }
             }
 

--- a/src/com/cloudflare/api/results/CloudflareErrorEnum.java
+++ b/src/com/cloudflare/api/results/CloudflareErrorEnum.java
@@ -6,6 +6,14 @@ package com.cloudflare.api.results;
  */
 public enum CloudflareErrorEnum {
 
+    UNKNOWN_ERROR {
+    	
+        @Override
+        public CloudflareError getException(String msg) {
+            return new CloudflareError(this.name(), "Cannot execute request", msg);
+        }
+    },
+
     E_UNAUTH {
         @Override
         public CloudflareError getException(String msg) {


### PR DESCRIPTION
Hi @LoadLow,

While using Cloudflare API I was hit by the problem described in https://github.com/sarxos/cloudflare-api/issues/1. This pull request is to cherry pick this change onto your code base.

The previous stack trace:

``` plain
Exception in thread "pool-1-thread-16" net.sf.json.JSONException: JSONObject["err_code"] not found.
    at net.sf.json.JSONObject.getString(JSONObject.java:2092)
    at com.cloudflare.api.requests.CloudflareRequest.executeBasic(CloudflareRequest.java:90)
    at com.cloudflare.api.requests.purge.PurgeCacheFile.execute(PurgeCacheFile.java:21)
    at x.x.x.CloudflareService.purge(CloudflareService.java:42)
    at A$1.run(A.java:21)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
```

After the change:

``` plain
com.cloudflare.api.results.CloudflareError: [UNKNOWN_ERROR] : Cannot execute request :: Purge rate limited.
    at com.cloudflare.api.results.CloudflareErrorEnum$1.getException(CloudflareErrorEnum.java:13) ~[classes/:na]
    at com.cloudflare.api.requests.CloudflareRequest.executeBasic(CloudflareRequest.java:105) ~[classes/:na]
    at com.cloudflare.api.requests.purge.PurgeCacheFile.execute(PurgeCacheFile.java:21) ~[classes/:na]
    at x.x.x.CloudflareService.purge(CloudflareService.java:42) ~[classes/:na]
    at A$1.run(A.java:21) [classes/:na]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_25]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_25]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_25]
```

The code I used to test it:

``` java
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;

import x.x.x.CloudflareService;


public class A {

    public static void main(String[] args) {

        ExecutorService executor = Executors.newFixedThreadPool(20);

        final CloudflareService cdn = new CloudflareService();

        for (int i = 0; i < 101; i++) {
            final int k = i;
            executor.execute(new Runnable() {

                @Override
                public void run() {
                    cdn.purge(k + "test.js");
                }
            });
        }
    }
}
```
